### PR TITLE
Remove import breaking typescript build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `passwordlessLogin` method takes optional login mode (`login` or `register`)
 
+### Fixed
+
+- removed `RequestInit` and `Response` import from `cross-fetch`
+
 ## [0.0.5] - 2021-04-14
 
 ### Changed

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,4 @@
 import * as crossfetch from 'cross-fetch';
-import { RequestInit, Response } from 'cross-fetch/lib.fetch';
 
 import { AuthToken, ClientOptions, RefreshAccessTokenOptions } from '.';
 import {


### PR DESCRIPTION
The import is not necessary as `RequestInit` and `Response`. They are part of `dom` lib.