### PR TITLE
Fix publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,8 @@ jobs:
           echo Publishing @superfaceai/service-client version ${NEW_VERSION}
           yarn version --new-version ${NEW_VERSION} --no-git-tag-version
 
-      # Publish version to private repository
+      # Publish version to public repository
       - name: Publish
-        run: yarn publish --new-version ${NEW_VERSION} --verbose
+        run: yarn publish --new-version ${NEW_VERSION} --verbose --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_BOT_PAT }}


### PR DESCRIPTION
This PR is addressing this error in package publish workflow: 

`Couldn't publish package: "https://registry.npmjs.org/@superfaceai%2fservice-client: You must sign up for private packages`

See Github actions log:
https://github.com/superfaceai/service-client/runs/2447379600?check_suite_focus=true
