### PR TITLE
Release 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] - 2021-04-29
+
+### Fixed
+
+- Release script
+
 ## [0.0.10] - 2021-04-27
 
 ### Added


### PR DESCRIPTION
I read documentation badly.

Package can be republish after 24 hours, but package version can't be changed ever.

https://www.npmjs.com/policies/unpublish

<img width="725" alt="image" src="https://user-images.githubusercontent.com/959390/116568000-6be60000-a908-11eb-8e31-549220cbf089.png">

And error returned while trying to publish:
<img width="933" alt="image" src="https://user-images.githubusercontent.com/959390/116568094-7e603980-a908-11eb-901a-6c0111b61bee.png">

