### PR TITLE
Trigger publish when marked as released

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
Believe that right event to trigger publish workflow is `published` instead of `created`.
This should trigger build when release is created first as draft and later published.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release