### PR TITLE
Set prototype for custom errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Custom errors have properly set prototype as described in TypeScript [Documentation](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work).
+
 ## [0.0.13] - 2021-05-14
 ### Changed
 - Service Client throws custom errors. `ServiceClientError` as generic error from Service Client and `ServiceApiError` as error when non 2xx response is received from service apis.

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,0 +1,24 @@
+import { ServiceApiError, ServiceClientError } from './errors';
+
+describe('errors', () => {
+  describe('ServiceClientError', () => {
+    it('should work with instanceof operator', () => {
+      const error = new ServiceClientError('Service Client Error');
+
+      expect(error instanceof ServiceClientError).toBeTruthy();
+    });
+  });
+
+  describe('ServiceApiError', () => {
+    it('should work with instanceof operator', () => {
+      const error = new ServiceApiError({
+        status: 500,
+        title: 'Error',
+        detail: 'Test error',
+        instance: '/mocked',
+      });
+
+      expect(error instanceof ServiceApiError).toBeTruthy();
+    });
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,11 @@
 import { ServiceApiErrorResponse } from './interfaces';
 
-export class ServiceClientError extends Error {}
+export class ServiceClientError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, ServiceClientError.prototype);
+  }
+}
 
 export class ServiceApiError extends ServiceClientError {
   public status: number;
@@ -12,6 +17,8 @@ export class ServiceApiError extends ServiceClientError {
     super(
       `Store responded with status: ${errorResponse.status} on: ${errorResponse.instance} ${errorResponse.title}: ${errorResponse.detail}`
     );
+
+    Object.setPrototypeOf(this, ServiceApiError.prototype);
 
     this.status = errorResponse.status;
     this.instance = errorResponse.instance;


### PR DESCRIPTION
I didn't specify custom error classes correctly according to https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

this PR is fixing it and adding test to ensure `instanceof` operator works.