### PR TITLE
Mark prepatch, preminor, premajor release levels as prerelease

### DIFF
--- a/.github/workflows/release.js.yml
+++ b/.github/workflows/release.js.yml
@@ -96,5 +96,6 @@ jobs:
         with:
           tag_name: ${{ env.NEW_VERSION }}
           body: ${{ steps.get-changelog.outputs.changelog }}
+          prerelease: ${{ startsWith(github.event.inputs.release-level, 'pre') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release workflow marks Github release as prerelease for prepatch, preminor, premajor release levels.