### PR TITLE
Getting profile or map should not require scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING CHANGE** `getProfile`, `getProfileAST`, `getProfileSource` arguments changed
+- parameters `scope` and `version` are  optional in `getProfile`, `getProfileAST`, `getProfileSource` functions
 
 ## [0.0.26] - 2021-10-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING CHANGE** `getProfile`, `getProfileAST`, `getProfileSource` arguments changed
 - parameters `scope` and `version` are  optional in `getProfile`, `getProfileAST`, `getProfileSource` functions
+- **BREAKING CHANGE** `getMap`, `getMapAST`, `getMapSource` arguments changed
+- parameter `scope` and `version` are optional in `getMap`, `getMapAST`, `getMapSource` functions
 
 ## [0.0.26] - 2021-10-22
 ### Fixed

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1457,7 +1457,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMap('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMap({
+          name: 'user-repos',
+          provider: 'github',
+          scope: 'vcs',
+          version: '1.0.0',
+        })
       ).resolves.toEqual(mockResult);
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {
@@ -1484,7 +1489,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMap('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMap({
+          name: 'user-repos',
+          provider: 'github',
+          scope: 'vcs',
+          version: '1.0.0',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {
@@ -1583,7 +1593,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMapSource('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMapSource({
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual('mapSource');
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {
@@ -1610,7 +1625,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMapSource('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMapSource({
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {
@@ -1633,7 +1653,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMapAST('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMapAST({
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual('mapAST');
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {
@@ -1660,7 +1685,12 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getMapAST('vcs', '1.0.0', 'user-repos', 'github')
+        client.getMapAST({
+          name: 'user-repos',
+          provider: 'github',
+          scope: 'vcs',
+          version: '1.0.0',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos.github@1.0.0', {

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1096,7 +1096,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfile('vcs', '1.0.0', 'user-repos')
+        client.getProfile({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual(mockResult);
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
@@ -1123,7 +1127,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfile('vcs', '1.0.0', 'user-repos')
+        client.getProfile({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
@@ -1220,7 +1228,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfileSource('vcs', '1.0.0', 'user-repos')
+        client.getProfileSource({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual('profileSource');
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
@@ -1247,7 +1259,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfileSource('vcs', '1.0.0', 'user-repos')
+        client.getProfileSource({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
@@ -1270,7 +1286,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfileAST('vcs', '1.0.0', 'user-repos')
+        client.getProfileAST({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual('profileAST');
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
@@ -1297,7 +1317,11 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(
-        client.getProfileAST('vcs', '1.0.0', 'user-repos')
+        client.getProfileAST({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).rejects.toEqual(new ServiceApiError(payload));
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,11 +49,13 @@ import {
   PasswordlessLoginResponse,
   UnsuccessfulLogin,
 } from './interfaces/login_api_response';
+import { MapId } from './interfaces/map_id';
 import { ProjectUpdateBody } from './interfaces/projects_api_options';
 import {
   ProjectResponse,
   ProjectsListResponse,
 } from './interfaces/projects_api_response';
+import { buildMapUrl } from './utils/buildMapUrl';
 import { buildProfileUrl } from './utils/buildProfileUrl';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -385,16 +387,8 @@ export class ServiceClient {
     return (await this.unwrap(response)).text();
   }
 
-  async getMap(
-    scope: string,
-    version: string,
-    name: string,
-    provider: string,
-    variant?: string
-  ): Promise<MapRevisionResponse> {
-    const url = variant
-      ? `/${scope}/${name}.${provider}.${variant}@${version}`
-      : `/${scope}/${name}.${provider}@${version}`;
+  async getMap(mapId: MapId): Promise<MapRevisionResponse> {
+    const url = buildMapUrl(mapId);
     const response: Response = await this.fetch(url, {
       authenticate: false,
       method: 'GET',
@@ -408,16 +402,8 @@ export class ServiceClient {
     return (await response.json()) as MapRevisionResponse;
   }
 
-  async getMapSource(
-    scope: string,
-    version: string,
-    name: string,
-    provider: string,
-    variant?: string
-  ): Promise<string> {
-    const url = variant
-      ? `/${scope}/${name}.${provider}.${variant}@${version}`
-      : `/${scope}/${name}.${provider}@${version}`;
+  async getMapSource(mapId: MapId): Promise<string> {
+    const url = buildMapUrl(mapId);
     const response: Response = await this.fetch(url, {
       authenticate: false,
       method: 'GET',
@@ -429,16 +415,8 @@ export class ServiceClient {
     return (await this.unwrap(response)).text();
   }
 
-  async getMapAST(
-    scope: string,
-    version: string,
-    name: string,
-    provider: string,
-    variant?: string
-  ): Promise<string> {
-    const url = variant
-      ? `/${scope}/${name}.${provider}.${variant}@${version}`
-      : `/${scope}/${name}.${provider}@${version}`;
+  async getMapAST(mapId: MapId): Promise<string> {
+    const url = buildMapUrl(mapId);
     const response: Response = await this.fetch(url, {
       authenticate: false,
       method: 'GET',

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,7 @@ import {
   MapRevisionResponse,
   MapsListOptions,
   MapsListResponse,
+  ProfileId,
   ProfilesListOptions,
   ProfilesListResponse,
   ProfileVersionResponse,
@@ -53,6 +54,7 @@ import {
   ProjectResponse,
   ProjectsListResponse,
 } from './interfaces/projects_api_response';
+import { buildProfileUrl } from './utils/buildProfileUrl';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -301,60 +303,39 @@ export class ServiceClient {
     return (await this.unwrap(response)).text();
   }
 
-  async getProfile(
-    scope: string,
-    version: string,
-    name: string
-  ): Promise<ProfileVersionResponse> {
-    const response: Response = await this.fetch(
-      `/${scope}/${name}@${version}`,
-      {
-        authenticate: false,
-        method: 'GET',
-        headers: {
-          Accept: MEDIA_TYPE_JSON,
-        },
-      }
-    );
+  async getProfile(profileId: ProfileId): Promise<ProfileVersionResponse> {
+    const response: Response = await this.fetch(buildProfileUrl(profileId), {
+      authenticate: false,
+      method: 'GET',
+      headers: {
+        Accept: MEDIA_TYPE_JSON,
+      },
+    });
     await this.unwrap(response);
 
     return (await response.json()) as ProfileVersionResponse;
   }
 
-  async getProfileSource(
-    scope: string,
-    version: string,
-    name: string
-  ): Promise<string> {
-    const response: Response = await this.fetch(
-      `/${scope}/${name}@${version}`,
-      {
-        authenticate: false,
-        method: 'GET',
-        headers: {
-          Accept: MEDIA_TYPE_PROFILE,
-        },
-      }
-    );
+  async getProfileSource(profileId: ProfileId): Promise<string> {
+    const response: Response = await this.fetch(buildProfileUrl(profileId), {
+      authenticate: false,
+      method: 'GET',
+      headers: {
+        Accept: MEDIA_TYPE_PROFILE,
+      },
+    });
 
     return (await this.unwrap(response)).text();
   }
 
-  async getProfileAST(
-    scope: string,
-    version: string,
-    name: string
-  ): Promise<string> {
-    const response: Response = await this.fetch(
-      `/${scope}/${name}@${version}`,
-      {
-        authenticate: false,
-        method: 'GET',
-        headers: {
-          Accept: MEDIA_TYPE_PROFILE_AST,
-        },
-      }
-    );
+  async getProfileAST(profileId: ProfileId): Promise<string> {
+    const response: Response = await this.fetch(buildProfileUrl(profileId), {
+      authenticate: false,
+      method: 'GET',
+      headers: {
+        Accept: MEDIA_TYPE_PROFILE_AST,
+      },
+    });
 
     return (await this.unwrap(response)).text();
   }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -6,6 +6,7 @@ export * from './login_api_response';
 export * from './maps_api_response';
 export * from './maps_api_options';
 export * from './refresh_access_token_options';
+export * from './profile_id';
 export * from './profiles_api_response';
 export * from './profiles_api_options';
 export * from './projects_api_response';

--- a/src/interfaces/map_id.ts
+++ b/src/interfaces/map_id.ts
@@ -1,0 +1,7 @@
+export interface MapId {
+  name: string;
+  provider: string;
+  version: string;
+  scope?: string;
+  variant?: string;
+}

--- a/src/interfaces/profile_id.ts
+++ b/src/interfaces/profile_id.ts
@@ -1,0 +1,5 @@
+export interface ProfileId {
+  name: string;
+  version?: string;
+  scope?: string;
+}

--- a/src/utils/buildMapUrl.spec.ts
+++ b/src/utils/buildMapUrl.spec.ts
@@ -1,0 +1,47 @@
+import { buildMapUrl } from './buildMapUrl';
+
+describe('buildMapUrl', () => {
+  it('should build url', () => {
+    const url = buildMapUrl({
+      name: 'profile',
+      provider: 'provider',
+      version: '1.0',
+    });
+
+    expect(url).toBe('/profile.provider@1.0');
+  });
+
+  it('should build url with scope', () => {
+    const url = buildMapUrl({
+      name: 'profile',
+      provider: 'provider',
+      version: '1.0',
+      scope: 'scope',
+    });
+
+    expect(url).toBe('/scope/profile.provider@1.0');
+  });
+
+  it('should build url with variant', () => {
+    const url = buildMapUrl({
+      name: 'profile',
+      provider: 'provider',
+      version: '1.0',
+      variant: 'variant',
+    });
+
+    expect(url).toBe('/profile.provider.variant@1.0');
+  });
+
+  it('should build url with version, scope, variant', () => {
+    const url = buildMapUrl({
+      name: 'profile',
+      provider: 'provider',
+      version: '1.0',
+      scope: 'scope',
+      variant: 'variant',
+    });
+
+    expect(url).toBe('/scope/profile.provider.variant@1.0');
+  });
+});

--- a/src/utils/buildMapUrl.ts
+++ b/src/utils/buildMapUrl.ts
@@ -1,0 +1,18 @@
+import { MapId } from '../interfaces/map_id';
+
+export function buildMapUrl(mapId: MapId) {
+  const mapIdComponents = [];
+  if (mapId.scope) {
+    mapIdComponents.push(`/${mapId.scope}`);
+  }
+  mapIdComponents.push(`/${mapId.name}`);
+  mapIdComponents.push(`.${mapId.provider}`);
+  if (mapId.variant) {
+    mapIdComponents.push(`.${mapId.variant}`);
+  }
+  if (mapId.version) {
+    mapIdComponents.push(`@${mapId.version}`);
+  }
+
+  return mapIdComponents.join('');
+}

--- a/src/utils/buildProfileUrl.spec.ts
+++ b/src/utils/buildProfileUrl.spec.ts
@@ -1,0 +1,37 @@
+import { buildProfileUrl } from './buildProfileUrl';
+
+describe('buildProfileUrl', () => {
+  it('should build profile url', () => {
+    const url = buildProfileUrl({ name: 'profile' });
+
+    expect(url).toBe('/profile');
+  });
+
+  it('should build profile url with scope', () => {
+    const url = buildProfileUrl({
+      name: 'profile',
+      scope: 'scope',
+    });
+
+    expect(url).toBe('/scope/profile');
+  });
+
+  it('should build profile url with version', () => {
+    const url = buildProfileUrl({
+      name: 'profile',
+      version: '1.0.0',
+    });
+
+    expect(url).toBe('/profile@1.0.0');
+  });
+
+  it('should build profile url with scope and version', () => {
+    const url = buildProfileUrl({
+      name: 'profile',
+      scope: 'scope',
+      version: '1.0.0',
+    });
+
+    expect(url).toBe('/scope/profile@1.0.0');
+  });
+});

--- a/src/utils/buildProfileUrl.ts
+++ b/src/utils/buildProfileUrl.ts
@@ -1,0 +1,13 @@
+import { ProfileId } from '../interfaces';
+
+export function buildProfileUrl(profileId: ProfileId) {
+  if (profileId?.scope) {
+    return profileId.version
+      ? `/${profileId.scope}/${profileId.name}@${profileId.version}`
+      : `/${profileId.scope}/${profileId.name}`;
+  } else {
+    return profileId?.version
+      ? `/${profileId.name}@${profileId.version}`
+      : `/${profileId.name}`;
+  }
+}

--- a/test/client.e2e-spec.ts
+++ b/test/client.e2e-spec.ts
@@ -509,7 +509,12 @@ describe('client', () => {
 
     test('get map', async () => {
       await expect(
-        serviceClient.getMap('vcs', '1.0.0', 'user-repos', 'github')
+        serviceClient.getMap({
+          scope: 'vcs',
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+        })
       ).resolves.toEqual({
         ...mockResult,
         published_at: mockResult.published_at.toJSON(),
@@ -518,12 +523,22 @@ describe('client', () => {
 
     test('get map source', async () => {
       await expect(
-        serviceClient.getMapSource('vcs', '1.0.0', 'user-repos', 'github')
+        serviceClient.getMapSource({
+          scope: 'vcs',
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+        })
       ).resolves.toEqual(mockMapSource);
     });
     test('get map AST', async () => {
       await expect(
-        serviceClient.getMapAST('vcs', '1.0.0', 'user-repos', 'github')
+        serviceClient.getMapAST({
+          scope: 'vcs',
+          name: 'user-repos',
+          provider: 'github',
+          version: '1.0.0',
+        })
       ).resolves.toEqual(JSON.stringify(mockMapAST));
     });
 

--- a/test/client.e2e-spec.ts
+++ b/test/client.e2e-spec.ts
@@ -323,6 +323,23 @@ describe('client', () => {
           res.json(mockResult);
         }
       );
+      identity.get(
+        '/vcs/user-repos',
+        (req: express.Request, res: express.Response) => {
+          switch (req.headers?.accept) {
+            case MEDIA_TYPE_JSON:
+            case MEDIA_TYPE_PROFILE:
+            case MEDIA_TYPE_PROFILE_AST:
+              res.setHeader('location', '/vcs/user-repos@1.0.0');
+              res.sendStatus(302);
+              break;
+            default:
+              res.sendStatus(400);
+              break;
+          }
+          res.json(mockResult);
+        }
+      );
       identityServer = identity.listen(IDENTITY_PROVIDER_PORT);
       serviceClient = new ServiceClient();
       serviceClient.setOptions({
@@ -349,7 +366,20 @@ describe('client', () => {
 
     test('get profile', async () => {
       await expect(
-        serviceClient.getProfile('vcs', '1.0.0', 'user-repos')
+        serviceClient.getProfile({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
+      ).resolves.toEqual({
+        ...mockResult,
+        published_at: mockResult.published_at.toJSON(),
+      });
+    });
+
+    test('get profile without version', async () => {
+      await expect(
+        serviceClient.getProfile({ name: 'user-repos', scope: 'vcs' })
       ).resolves.toEqual({
         ...mockResult,
         published_at: mockResult.published_at.toJSON(),
@@ -358,12 +388,21 @@ describe('client', () => {
 
     test('get profile source', async () => {
       await expect(
-        serviceClient.getProfileSource('vcs', '1.0.0', 'user-repos')
+        serviceClient.getProfileSource({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual(mockProfileSource);
     });
+
     test('get profile AST', async () => {
       await expect(
-        serviceClient.getProfileAST('vcs', '1.0.0', 'user-repos')
+        serviceClient.getProfileAST({
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        })
       ).resolves.toEqual(JSON.stringify(mockProfileAST));
     });
 

--- a/test/client.e2e-spec.ts
+++ b/test/client.e2e-spec.ts
@@ -773,9 +773,10 @@ function runMockedPasswordlessIdentityServer(
       if (email) {
         res.status(200).send({
           verify_url: `${baseUrl}/auth/passwordless/verify?email=${encodeURIComponent(
-            email
+            email as unknown as string
           )}&token=${TOKEN_VALUE}`,
-          expires_at: identityServerState.verificationTokenExpiresAt.toISOString(),
+          expires_at:
+            identityServerState.verificationTokenExpiresAt.toISOString(),
         });
       } else {
         res.status(400);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This PR fixes `getProfile`, `getProfileAST`, `getProfileSource`, `getMap`, `getMapAST`, `getMapSource` functions. Parameters `scope` and `version` are no longer required to get profile or map resources.

**BREAKING CHANGE** Parameters of `getProfile*` and `getMap*` functions has been changed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes: https://github.com/superfaceai/service-client/issues/67

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
