### PR TITLE
Custom query params for passwordless and GitHub authentication

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -707,6 +707,17 @@ describe('client', () => {
         )}&mode=register`
       );
     });
+
+    it('should return github login url with utm_source query prameter', () => {
+      const returnTo = 'https://superface.dev/login/callback';
+      expect(
+        client.getGithubLoginUrl(returnTo, 'register', { utm_source: 'test' })
+      ).toBe(
+        `${BASE_URL}/auth/github?return_to=${encodeURIComponent(
+          returnTo
+        )}&mode=register&utm_source=test`
+      );
+    });
   });
 
   describe('createProvider', () => {
@@ -917,7 +928,9 @@ describe('client', () => {
       const fetchMock = jest
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
-      await expect(client.getProvider('test')).resolves.toStrictEqual(mockResult);
+      await expect(client.getProvider('test')).resolves.toStrictEqual(
+        mockResult
+      );
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/providers/test', {
         authenticate: false,
@@ -1912,9 +1925,7 @@ describe('client', () => {
       ).resolves.toEqual(mockResult);
 
       expect(fetchMock).toBeCalledTimes(1);
-      expect(
-        fetchMock
-      ).toBeCalledWith(
+      expect(fetchMock).toBeCalledWith(
         `/insights/sdk_config?account_handle=${accountHandle}&project_name=${projectName}`,
         { method: 'GET', headers: { 'Content-Type': 'application/json' } }
       );
@@ -1941,9 +1952,7 @@ describe('client', () => {
 
       expect(fetchMock).toBeCalledTimes(1);
 
-      expect(
-        fetchMock
-      ).toBeCalledWith(
+      expect(fetchMock).toBeCalledWith(
         `/insights/sdk_config?account_handle=${accountHandle}&project_name=${projectName}`,
         { method: 'GET', headers: { 'Content-Type': 'application/json' } }
       );

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -386,6 +386,15 @@ describe('client', () => {
             'Cannot deserialize login API response: FetchError: invalid json response body at  reason: Unexpected token B in JSON at position 4',
         });
       });
+
+      it('should send custom query parameters', async () => {
+        await client.passwordlessLogin('mail@mydomain.com', 'register', {
+          utm_content: 'test',
+        });
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://superface.ai/auth/passwordless?mode=register&utm_content=test'
+        );
+      });
     });
 
     describe('verifyPasswordlessLogin', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as crossfetch from 'cross-fetch';
+import { URL } from 'url';
 
 import {
   MEDIA_TYPE_JSON,
@@ -488,20 +489,21 @@ export class ServiceClient {
 
   public async passwordlessLogin(
     email: string,
-    mode: 'login' | 'register' = 'login'
+    mode: 'login' | 'register' = 'login',
+    customQueryParams: Record<string, any> = {}
   ): Promise<PasswordlessLoginResponse> {
-    const response: Response = await crossfetch.fetch(
-      `${this._STORAGE.baseUrl}/auth/passwordless?mode=${mode}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: email,
-        }),
-      }
-    );
+    const url = new URL(`${this._STORAGE.baseUrl}/auth/passwordless`);
+    url.search = new URLSearchParams({ mode, ...customQueryParams }).toString();
+
+    const response: Response = await crossfetch.fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: email,
+      }),
+    });
     if (response.status === 200) {
       const apiResponse = await this.tryParseLoginResponseJson<{
         verify_url: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -848,20 +848,29 @@ export class ServiceClient {
     }
   }
 
-  public getGithubLoginUrl(returnTo?: string, mode?: 'register'): string {
-    const urlWithoutParams = `${this._STORAGE.baseUrl}/auth/github`;
-    const queryParams = [];
+  public getGithubLoginUrl(
+    returnTo?: string,
+    mode?: 'register',
+    customQueryParams: Record<string, any> = {}
+  ): string {
+    const url = new URL(`${this._STORAGE.baseUrl}/auth/github`);
+    let queryParams: Record<string, any> = {};
+
     if (returnTo) {
-      queryParams.push(`return_to=${encodeURIComponent(returnTo)}`);
-    }
-    if (mode) {
-      queryParams.push(`mode=${mode}`);
-    }
-    if (queryParams.length > 0) {
-      return urlWithoutParams + `?${queryParams.join('&')}`;
+      queryParams.return_to = returnTo;
     }
 
-    return urlWithoutParams;
+    if (mode) {
+      queryParams.mode = mode;
+    }
+
+    if (customQueryParams) {
+      queryParams = { ...queryParams, ...customQueryParams };
+    }
+
+    url.search = new URLSearchParams(queryParams).toString();
+
+    return url.toString();
   }
 
   public async getUserInfo(): Promise<UserResponse> {
@@ -1029,7 +1038,7 @@ export class ServiceClient {
       return providerData as ProviderResponse;
     } else {
       const { url, ...providerJson } = providerData;
-      
+
       return {
         provider_id: providerData.name,
         url,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR adds to  `passwordless` and `getGithubLoginUrl` one more argument to be able to pass any query parameters.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want mark users in CRM after registration with campaign they came from.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
