### PR TITLE
Add authenticate option to `getProfile*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `authenticate` option to `getProfile`, `getProfileAST`, `getProfileSource` functions
 
 ## [1.0.1] - 2021-11-23
 ### Fixed

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1076,22 +1076,22 @@ describe('client', () => {
     });
   });
   describe('getProfile', () => {
-    it('should get one profile', async () => {
-      const mockResult: ProfileVersionResponse = {
-        profile_id: 'testId',
-        profile_name: 'testName',
-        profile_version: '1.0.0',
-        url: 'testUrl',
-        published_at: new Date(),
-        published_by: 'test',
-        owner: 'testOwner',
-        owner_url: 'testOwnerUrl',
-      };
+    const mockResult: ProfileVersionResponse = {
+      profile_id: 'testId',
+      profile_name: 'testName',
+      profile_version: '1.0.0',
+      url: 'testUrl',
+      published_at: new Date(),
+      published_by: 'test',
+      owner: 'testOwner',
+      owner_url: 'testOwnerUrl',
+    };
+    const mockResponse = {
+      ok: true,
+      json: async () => mockResult,
+    };
 
-      const mockResponse = {
-        ok: true,
-        json: async () => mockResult,
-      };
+    it('should get one profile', async () => {
       const fetchMock = jest
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
@@ -1105,6 +1105,29 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
         authenticate: false,
+        method: 'GET',
+        headers: {
+          Accept: MEDIA_TYPE_JSON,
+        },
+      });
+    });
+
+    it('should authenticate user', async () => {
+      const fetchMock = jest
+        .spyOn(client, 'fetch')
+        .mockResolvedValue(mockResponse as Response);
+      await client.getProfile(
+        {
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        },
+        {
+          authenticate: true,
+        }
+      );
+      expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
+        authenticate: true,
         method: 'GET',
         headers: {
           Accept: MEDIA_TYPE_JSON,
@@ -1145,21 +1168,21 @@ describe('client', () => {
   });
 
   describe('getProfilesList', () => {
-    it('should get list of profiles', async () => {
-      const mockResult: ProfilesListResponse = {
-        url: '/profiles',
-        data: [
-          {
-            id: 'scope/profile-name',
-            url: 'https://superface.test/scope/profile-name',
-          },
-        ],
-      };
+    const mockResult: ProfilesListResponse = {
+      url: '/profiles',
+      data: [
+        {
+          id: 'scope/profile-name',
+          url: 'https://superface.test/scope/profile-name',
+        },
+      ],
+    };
+    const mockResponse = {
+      ok: true,
+      json: async () => mockResult,
+    };
 
-      const mockResponse = {
-        ok: true,
-        json: async () => mockResult,
-      };
+    it('should get list of profiles', async () => {
       const fetchMock = jest
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
@@ -1192,6 +1215,18 @@ describe('client', () => {
       );
     });
 
+    it('should authenticate user', async () => {
+      const fetchMock = jest
+        .spyOn(client, 'fetch')
+        .mockResolvedValue(mockResponse as Response);
+      await client.getProfilesList({ authenticate: true });
+      expect(fetchMock).toBeCalledWith('/profiles', {
+        authenticate: true,
+        method: 'GET',
+        headers: { Accept: MEDIA_TYPE_JSON },
+      });
+    });
+
     it('should throw error', async () => {
       const payload = {
         status: 400,
@@ -1219,11 +1254,12 @@ describe('client', () => {
   });
 
   describe('getProfileSource', () => {
+    const mockResponse = {
+      ok: true,
+      text: async () => 'profileSource',
+    };
+
     it('should get profile source', async () => {
-      const mockResponse = {
-        ok: true,
-        text: async () => 'profileSource',
-      };
       const fetchMock = jest
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
@@ -1237,6 +1273,27 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
         authenticate: false,
+        method: 'GET',
+        headers: {
+          Accept: MEDIA_TYPE_PROFILE,
+        },
+      });
+    });
+
+    it('should authenticate user', async () => {
+      const fetchMock = jest
+        .spyOn(client, 'fetch')
+        .mockResolvedValue(mockResponse as Response);
+      await client.getProfileSource(
+        {
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        },
+        { authenticate: true }
+      );
+      expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
+        authenticate: true,
         method: 'GET',
         headers: {
           Accept: MEDIA_TYPE_PROFILE,
@@ -1277,11 +1334,12 @@ describe('client', () => {
   });
 
   describe('getProfileAST', () => {
+    const mockResponse = {
+      ok: true,
+      text: async () => 'profileAST',
+    };
+
     it('should get profile AST', async () => {
-      const mockResponse = {
-        ok: true,
-        text: async () => 'profileAST',
-      };
       const fetchMock = jest
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
@@ -1295,6 +1353,27 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
         authenticate: false,
+        method: 'GET',
+        headers: {
+          Accept: MEDIA_TYPE_PROFILE_AST,
+        },
+      });
+    });
+
+    it('should authenticate user', async () => {
+      const fetchMock = jest
+        .spyOn(client, 'fetch')
+        .mockResolvedValue(mockResponse as Response);
+      await client.getProfileAST(
+        {
+          name: 'user-repos',
+          version: '1.0.0',
+          scope: 'vcs',
+        },
+        { authenticate: true }
+      );
+      expect(fetchMock).toBeCalledWith('/vcs/user-repos@1.0.0', {
+        authenticate: true,
         method: 'GET',
         headers: {
           Accept: MEDIA_TYPE_PROFILE_AST,

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,7 @@ import {
   MapsListOptions,
   MapsListResponse,
   ProfileId,
+  ProfileOptions,
   ProfilesListOptions,
   ProfilesListResponse,
   ProfileVersionResponse,
@@ -304,9 +305,12 @@ export class ServiceClient {
     return (await this.unwrap(response)).text();
   }
 
-  async getProfile(profileId: ProfileId): Promise<ProfileVersionResponse> {
+  async getProfile(
+    profileId: ProfileId,
+    options?: ProfileOptions
+  ): Promise<ProfileVersionResponse> {
     const response: Response = await this.fetch(buildProfileUrl(profileId), {
-      authenticate: false,
+      authenticate: options?.authenticate ?? false,
       method: 'GET',
       headers: {
         Accept: MEDIA_TYPE_JSON,
@@ -317,9 +321,12 @@ export class ServiceClient {
     return (await response.json()) as ProfileVersionResponse;
   }
 
-  async getProfileSource(profileId: ProfileId): Promise<string> {
+  async getProfileSource(
+    profileId: ProfileId,
+    options?: ProfileOptions
+  ): Promise<string> {
     const response: Response = await this.fetch(buildProfileUrl(profileId), {
-      authenticate: false,
+      authenticate: options?.authenticate ?? false,
       method: 'GET',
       headers: {
         Accept: MEDIA_TYPE_PROFILE,
@@ -329,9 +336,12 @@ export class ServiceClient {
     return (await this.unwrap(response)).text();
   }
 
-  async getProfileAST(profileId: ProfileId): Promise<string> {
+  async getProfileAST(
+    profileId: ProfileId,
+    options?: ProfileOptions
+  ): Promise<string> {
     const response: Response = await this.fetch(buildProfileUrl(profileId), {
-      authenticate: false,
+      authenticate: options?.authenticate ?? false,
       method: 'GET',
       headers: {
         Accept: MEDIA_TYPE_PROFILE_AST,
@@ -352,7 +362,7 @@ export class ServiceClient {
     });
 
     const response: Response = await this.fetch(url, {
-      authenticate: false,
+      authenticate: options?.authenticate ?? false,
       method: 'GET',
       headers: { Accept: 'application/json' },
     });

--- a/src/interfaces/profiles_api_options.ts
+++ b/src/interfaces/profiles_api_options.ts
@@ -1,4 +1,8 @@
-export interface ProfilesListOptions {
+export interface ProfilesListOptions extends ProfileOptions {
   limit?: number;
   accountHandle?: string;
+}
+
+export interface ProfileOptions {
+  authenticate?: boolean;
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR adds `authenticate` option to `getProfile`, `getProfileAST`, `getProfileSource` and `getProfilesList` functions.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CLI needs to authenticate users when installing profiles.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
