### PR TITLE
Create provider and profile throws specific errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `createProvider` throws `CreateProviderApiError`
+- `createProfile` throws `CreateProfileApiError`
+
 
 ## [2.0.0] - 2022-04-12
 ### Changed

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -9,7 +9,12 @@ import {
   MEDIA_TYPE_PROFILE_AST,
   MEDIA_TYPE_TEXT,
 } from './constants';
-import { CreateProfileApiError, CreateProviderApiError, ServiceApiError, ServiceClientError } from './errors';
+import {
+  CreateProfileApiError,
+  CreateProviderApiError,
+  ServiceApiError,
+  ServiceClientError,
+} from './errors';
 import {
   CancellationToken,
   LoginConfirmationErrorCode,
@@ -755,7 +760,7 @@ describe('client', () => {
         title: 'Already exists',
         detail: 'Provider already exists',
         provider_json_equals: true,
-        valid_provider_names: ['valid-provider-name']
+        valid_provider_names: ['valid-provider-name'],
       };
       const mockResponse = {
         ok: false,
@@ -1006,7 +1011,7 @@ describe('client', () => {
         title: 'Already exists',
         detail: 'Profile already exists',
         content_is_equal: true,
-        suggested_version: '2.0.0'
+        suggested_version: '2.0.0',
       };
       const mockResponse = {
         ok: false,
@@ -1207,12 +1212,10 @@ describe('client', () => {
     });
 
     it('should use query params to filter profiles (if provided)', async () => {
-      const fetchMock = jest
-        .spyOn(client, 'fetch')
-        .mockResolvedValue({
-          ok: true,
-          json: async () => mockResult,
-        } as Response);
+      const fetchMock = jest.spyOn(client, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => mockResult,
+      } as Response);
 
       await client.getProfilesList({
         accountHandle: 'username',

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -9,7 +9,7 @@ import {
   MEDIA_TYPE_PROFILE_AST,
   MEDIA_TYPE_TEXT,
 } from './constants';
-import { ServiceApiError, ServiceClientError } from './errors';
+import { CreateProfileApiError, CreateProviderApiError, ServiceApiError, ServiceClientError } from './errors';
 import {
   CancellationToken,
   LoginConfirmationErrorCode,
@@ -754,6 +754,8 @@ describe('client', () => {
         instance: '/providers',
         title: 'Already exists',
         detail: 'Provider already exists',
+        provider_json_equals: true,
+        valid_provider_names: ['valid-provider-name']
       };
       const mockResponse = {
         ok: false,
@@ -763,7 +765,7 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(client.createProvider('test')).rejects.toEqual(
-        new ServiceApiError(payload)
+        new CreateProviderApiError(payload)
       );
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/providers', {
@@ -1003,6 +1005,8 @@ describe('client', () => {
         instance: '/profiles',
         title: 'Already exists',
         detail: 'Profile already exists',
+        content_is_equal: true,
+        suggested_version: '2.0.0'
       };
       const mockResponse = {
         ok: false,
@@ -1012,7 +1016,7 @@ describe('client', () => {
         .spyOn(client, 'fetch')
         .mockResolvedValue(mockResponse as Response);
       await expect(client.createProfile('test')).rejects.toEqual(
-        new ServiceApiError(payload)
+        new CreateProfileApiError(payload)
       );
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/profiles', {

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,12 @@ import {
   MEDIA_TYPE_PROFILE_AST,
   MEDIA_TYPE_TEXT,
 } from './constants';
-import { CreateProfileApiError, CreateProviderApiError, ServiceApiError, ServiceClientError } from './errors';
+import {
+  CreateProfileApiError,
+  CreateProviderApiError,
+  ServiceApiError,
+  ServiceClientError,
+} from './errors';
 import {
   AuthToken,
   ClientOptions,
@@ -245,9 +250,12 @@ export class ServiceClient {
         'Content-Type': 'application/json',
       },
     });
-    await this.unwrap<CreateProviderApiErrorResponse>(response, (errorResponse) => {
-      throw new CreateProviderApiError(errorResponse);
-    });
+    await this.unwrap<CreateProviderApiErrorResponse>(
+      response,
+      errorResponse => {
+        throw new CreateProviderApiError(errorResponse);
+      }
+    );
   }
 
   async getProvidersList(
@@ -294,9 +302,12 @@ export class ServiceClient {
         'Content-Type': MEDIA_TYPE_TEXT,
       },
     });
-    await this.unwrap<CreateProfileApiErrorResponse>(response, (errorResponse) => {
-      throw new CreateProfileApiError(errorResponse);
-    });
+    await this.unwrap<CreateProfileApiErrorResponse>(
+      response,
+      errorResponse => {
+        throw new CreateProfileApiError(errorResponse);
+      }
+    );
   }
 
   async parseProfile(payload: string): Promise<string> {
@@ -931,12 +942,16 @@ export class ServiceClient {
     return Math.floor(Date.now() / 1000);
   }
 
-  private async unwrap<ApiErrorResponse extends ServiceApiErrorResponse>(response: Response, throwCustomError?: (errorResponse: ApiErrorResponse) => void): Promise<Response> {
+  private async unwrap<ApiErrorResponse extends ServiceApiErrorResponse>(
+    response: Response,
+    throwCustomError?: (errorResponse: ApiErrorResponse) => void
+  ): Promise<Response> {
     if (!response.ok) {
-      if(throwCustomError) {
-        throwCustomError((await response.json()) as ApiErrorResponse)
+      if (throwCustomError) {
+        throwCustomError((await response.json()) as ApiErrorResponse);
       } else {
-        const errorResponse = (await response.json()) as ServiceApiErrorResponse;
+        const errorResponse =
+          (await response.json()) as ServiceApiErrorResponse;
         throw new ServiceApiError(errorResponse);
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ import {
   MEDIA_TYPE_PROFILE_AST,
   MEDIA_TYPE_TEXT,
 } from './constants';
-import { ServiceApiError, ServiceClientError } from './errors';
+import { CreateProfileApiError, CreateProviderApiError, ServiceApiError, ServiceClientError } from './errors';
 import {
   AuthToken,
   ClientOptions,
@@ -42,6 +42,8 @@ import {
   VerifyOptions,
   VerifyResponse,
 } from './interfaces';
+import { CreateProfileApiErrorResponse } from './interfaces/create_profile_api_error_response';
+import { CreateProviderApiErrorResponse } from './interfaces/create_provider_api_error_response';
 import { UserResponse } from './interfaces/identity_api_response';
 import {
   CLILoginResponse,
@@ -243,7 +245,9 @@ export class ServiceClient {
         'Content-Type': 'application/json',
       },
     });
-    await this.unwrap(response);
+    await this.unwrap<CreateProviderApiErrorResponse>(response, (errorResponse) => {
+      throw new CreateProviderApiError(errorResponse);
+    });
   }
 
   async getProvidersList(
@@ -290,7 +294,9 @@ export class ServiceClient {
         'Content-Type': MEDIA_TYPE_TEXT,
       },
     });
-    await this.unwrap(response);
+    await this.unwrap<CreateProfileApiErrorResponse>(response, (errorResponse) => {
+      throw new CreateProfileApiError(errorResponse);
+    });
   }
 
   async parseProfile(payload: string): Promise<string> {
@@ -925,10 +931,14 @@ export class ServiceClient {
     return Math.floor(Date.now() / 1000);
   }
 
-  private async unwrap(response: Response): Promise<Response> {
+  private async unwrap<ApiErrorResponse extends ServiceApiErrorResponse>(response: Response, throwCustomError?: (errorResponse: ApiErrorResponse) => void): Promise<Response> {
     if (!response.ok) {
-      const errorResponse = (await response.json()) as ServiceApiErrorResponse;
-      throw new ServiceApiError(errorResponse);
+      if(throwCustomError) {
+        throwCustomError((await response.json()) as ApiErrorResponse)
+      } else {
+        const errorResponse = (await response.json()) as ServiceApiErrorResponse;
+        throw new ServiceApiError(errorResponse);
+      }
     }
 
     return response;

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,4 +1,4 @@
-import { ServiceApiError, ServiceClientError } from './errors';
+import { CreateProfileApiError, CreateProviderApiError, ServiceApiError, ServiceClientError } from './errors';
 
 describe('errors', () => {
   describe('ServiceClientError', () => {
@@ -19,6 +19,32 @@ describe('errors', () => {
       });
 
       expect(error instanceof ServiceApiError).toBeTruthy();
+    });
+  });
+
+  describe('CreateProviderApiError', () => {
+    it('should work with instanceof operator', () => {
+      const error = new CreateProviderApiError({
+        status: 500,
+        title: 'Error',
+        detail: 'Test error',
+        instance: '/mocked',
+      });
+
+      expect(error instanceof CreateProviderApiError).toBeTruthy();
+    });
+  });
+
+  describe('CreateProfileApiError', () => {
+    it('should work with instanceof operator', () => {
+      const error = new CreateProfileApiError({
+        status: 500,
+        title: 'Error',
+        detail: 'Test error',
+        instance: '/mocked',
+      });
+
+      expect(error instanceof CreateProfileApiError).toBeTruthy();
     });
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,6 @@
 import { ServiceApiErrorResponse } from './interfaces';
+import { CreateProfileApiErrorResponse } from './interfaces/create_profile_api_error_response';
+import { CreateProviderApiErrorResponse } from './interfaces/create_provider_api_error_response';
 
 export class ServiceClientError extends Error {
   constructor(message: string) {
@@ -24,5 +26,33 @@ export class ServiceApiError extends ServiceClientError {
     this.instance = errorResponse.instance;
     this.title = errorResponse.title;
     this.detail = errorResponse.detail;
+  }
+}
+
+export class CreateProviderApiError extends ServiceApiError {
+  public providerJsonEquals?: boolean;
+  public validProviderNames?: string[];
+
+  constructor(errorResponse: CreateProviderApiErrorResponse) {
+    super(errorResponse);
+
+    Object.setPrototypeOf(this, CreateProviderApiError.prototype);
+
+    this.providerJsonEquals = errorResponse.provider_json_equals;
+    this.validProviderNames = errorResponse.valid_provider_names;
+  }
+}
+
+export class CreateProfileApiError extends ServiceApiError {
+  public contentIsEqual?: boolean;
+  public suggestedVersion?: string;
+
+  constructor(errorResponse: CreateProfileApiErrorResponse) {
+    super(errorResponse);
+
+    Object.setPrototypeOf(this, CreateProfileApiError.prototype);
+
+    this.contentIsEqual = errorResponse.content_is_equal;
+    this.suggestedVersion = errorResponse.suggested_version;
   }
 }

--- a/src/interfaces/create_profile_api_error_response.ts
+++ b/src/interfaces/create_profile_api_error_response.ts
@@ -1,6 +1,6 @@
-import { ServiceApiErrorResponse } from "./service_api_error_response";
+import { ServiceApiErrorResponse } from './service_api_error_response';
 
 export interface CreateProfileApiErrorResponse extends ServiceApiErrorResponse {
-  content_is_equal?: boolean,
-  suggested_version?: string,
+  content_is_equal?: boolean;
+  suggested_version?: string;
 }

--- a/src/interfaces/create_profile_api_error_response.ts
+++ b/src/interfaces/create_profile_api_error_response.ts
@@ -1,0 +1,6 @@
+import { ServiceApiErrorResponse } from "./service_api_error_response";
+
+export interface CreateProfileApiErrorResponse extends ServiceApiErrorResponse {
+  content_is_equal?: boolean,
+  suggested_version?: string,
+}

--- a/src/interfaces/create_provider_api_error_response.ts
+++ b/src/interfaces/create_provider_api_error_response.ts
@@ -1,6 +1,7 @@
-import { ServiceApiErrorResponse } from "./service_api_error_response";
+import { ServiceApiErrorResponse } from './service_api_error_response';
 
-export interface CreateProviderApiErrorResponse extends ServiceApiErrorResponse {
-  provider_json_equals?: boolean,
-  valid_provider_names?: string[],
+export interface CreateProviderApiErrorResponse
+  extends ServiceApiErrorResponse {
+  provider_json_equals?: boolean;
+  valid_provider_names?: string[];
 }

--- a/src/interfaces/create_provider_api_error_response.ts
+++ b/src/interfaces/create_provider_api_error_response.ts
@@ -1,0 +1,6 @@
+import { ServiceApiErrorResponse } from "./service_api_error_response";
+
+export interface CreateProviderApiErrorResponse extends ServiceApiErrorResponse {
+  provider_json_equals?: boolean,
+  valid_provider_names?: string[],
+}


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->
This PR changes errors thrown by`createProvider` and `createProfile` to `CreateProviderApiError` and `CreateProfileApiError`.

This is not breaking change, `CreateProviderApiError` and `CreateProfileApiError` extends `ServiceApiError`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

So that clients can access specific error properties.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
