### PR TITLE
fix: SDKConfigResponse can contain null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING CHANGE** `SDKConfigResponse` introduces nullability to some fields
 
 ## [3.0.0] - 2022-05-16
 ### Added

--- a/src/interfaces/insights_api_response.ts
+++ b/src/interfaces/insights_api_response.ts
@@ -6,11 +6,11 @@ export interface SDKConfigResponse {
   configuration: {
     profiles: {
       [profile: string]: {
-        version: string;
+        version: string | null;
         providers: Array<{
           provider: string;
-          version: string;
-          priority: number;
+          version: string | null;
+          priority: number | null;
         }>;
       };
     };


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

The `SDKConfigResponse` interface correctly defines possible nullable values.

## Motivation and Context

Starting with OneSDK v2, the `SDKInit` event is not being sent to Brain when using with configuration in code. 

As a result, the request for `SDKConfig` resource [in Brain is calculated from Metrics events](https://github.com/superfaceai/brain/blob/main/apps/brain/src/insights/services/sdk_config.service.ts#L96-L101) which don't include profile version, provider version and priority.

This breaks expectations of clients (e.g. Air), resulting in unexpected behaviors. See [Slack for an example bug](https://superfaceai.slack.com/archives/C0263EBNUHH/p1662619125214909)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
