### PR TITLE
Nullable provider fields in map response interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING CHANGE** `MapResponse` and `MapRevisionResponse` may contain `null` values in `map_provider` and `map_provider_url` fields
 
 ## [4.0.0] - 2022-09-09
 ### Changed

--- a/src/interfaces/maps_api_response.ts
+++ b/src/interfaces/maps_api_response.ts
@@ -9,8 +9,8 @@ export interface MapMinimalResponse {
 
 export interface MapResponse {
   map_id: string;
-  map_provider: string;
-  map_provider_url: string;
+  map_provider: string | null;
+  map_provider_url: string | null;
   map_revision: string;
   map_variant: string | null;
   profile_name: string;
@@ -34,8 +34,8 @@ export interface MapRevisionResponse {
   profile_version: string;
   profile_url: string;
   map_revision: string;
-  map_provider: string;
-  map_provider_url: string;
+  map_provider: string | null;
+  map_provider_url: string | null;
   map_variant: string;
   url: string;
   published_at: Date;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR fixes `MapResponse` and `MapRevisionResponse` interfaces and allows `null` values in `map_provider` and `map_provider_url` fields.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We need to fix rendering of profiles with partly published Comlink documents.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
