### PR TITLE
feat: Access token getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `getAccessToken` method for fetching the access token that's up-to-date
 
 ## [5.0.0] - 2022-10-05
 ### Changed

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -338,11 +338,11 @@ describe('client', () => {
         result = await client.getAccessToken();
       });
 
-      it(`returns token`, async () => {
+      it('returns token', async () => {
         expect(result).toStrictEqual(stubToken);
       });
 
-      it(`doesn't call refreshAccessToken`, async () => {
+      it("doesn't call refreshAccessToken", async () => {
         expect(refreshAccessTokenMock).toBeCalledTimes(0);
       });
     });
@@ -354,7 +354,7 @@ describe('client', () => {
         result = await client.getAccessToken();
       });
 
-      it('calls refreshAccessToken & returns new token', async () => {
+      it('calls refreshAccessToken', async () => {
         expect(refreshAccessTokenMock).toBeCalledTimes(1);
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -207,6 +207,18 @@ export class ServiceClient {
     return authToken;
   }
 
+  public async getAccessToken(): Promise<AuthToken | null> {
+    if (!this._STORAGE?.authToken) {
+      return null;
+    }
+
+    if (this.isAccessTokenExpired()) {
+      return await this.refreshAccessToken();
+    }
+
+    return this._STORAGE.authToken;
+  }
+
   public async fetch(
     url: string,
     opts: RequestOptions = {}

--- a/src/client.ts
+++ b/src/client.ts
@@ -207,6 +207,12 @@ export class ServiceClient {
     return authToken;
   }
 
+  /**
+   * Returns current access token. If the access token is expired, the token
+   * is automatically refreshed and new token is returned.
+   * 
+   * @returns AuthToken | null
+   */
   public async getAccessToken(): Promise<AuthToken | null> {
     if (!this._STORAGE?.authToken) {
       return null;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

This PR adds `getAccessToken` method.

## Motivation and Context

We have new clients that use access token when interacting with our backends. They need to manually get and keep track of access token that 1) isn't exposed from the client 2) expires every 15 minutes.

The new `getAccessToken` method is a simple interface for getting the always up-to-date token.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
