### PR TITLE
Fix missing accept header in GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- missing Accept header in GET requests
 
 ## [5.2.0] - 2023-03-09
 ### Added

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -930,7 +930,7 @@ describe('client', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -959,7 +959,7 @@ describe('client', () => {
           authenticate: false,
           method: 'GET',
           headers: {
-            'Content-Type': 'application/json',
+            'Accept': 'application/json',
           },
         }
       );
@@ -987,7 +987,7 @@ describe('client', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -1023,7 +1023,7 @@ describe('client', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -1058,7 +1058,7 @@ describe('client', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -1085,7 +1085,7 @@ describe('client', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -2044,7 +2044,7 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith('/projects', {
         method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Accept': 'application/json' },
       });
     });
   });
@@ -2082,7 +2082,7 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith(`/projects/${owner}/${name}`, {
         method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Accept': 'application/json' },
       });
     });
 
@@ -2108,7 +2108,7 @@ describe('client', () => {
       expect(fetchMock).toBeCalledWith(`/projects/${owner}/${name}`, {
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
     });
@@ -2298,7 +2298,7 @@ describe('client', () => {
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock).toBeCalledWith(
         `/insights/sdk_config?account_handle=${accountHandle}&project_name=${projectName}`,
-        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+        { method: 'GET', headers: { 'Accept': 'application/json' } }
       );
     });
 
@@ -2325,7 +2325,7 @@ describe('client', () => {
 
       expect(fetchMock).toBeCalledWith(
         `/insights/sdk_config?account_handle=${accountHandle}&project_name=${projectName}`,
-        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+        { method: 'GET', headers: { 'Accept': 'application/json' } }
       );
     });
   });
@@ -2405,7 +2405,7 @@ describe('client', () => {
         `/insights/perform_statistics?${expectedUrlQuery}`,
         {
           method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Accept': 'application/json' },
         }
       );
     });
@@ -2441,7 +2441,7 @@ describe('client', () => {
         `/insights/perform_statistics?${expectedUrlQuery}`,
         {
           method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Accept': 'application/json' },
         }
       );
     });
@@ -2514,7 +2514,7 @@ describe('client', () => {
         `/insights/provider_changes?${expectedUrlQuery}`,
         {
           method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Accept': 'application/json' },
         }
       );
     });
@@ -2540,7 +2540,7 @@ describe('client', () => {
         `/insights/provider_changes?${expectedUrlQuery}`,
         {
           method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Accept': 'application/json' },
         }
       );
     });
@@ -2575,7 +2575,7 @@ describe('client', () => {
         `/insights/provider_changes?${expectedUrlQuery}`,
         {
           method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Accept': 'application/json' },
         }
       );
     });
@@ -2844,7 +2844,7 @@ describe('client', () => {
       await client.getUserInfo();
 
       expect(fetchSpy).toBeCalledWith('/id/user', {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Accept': 'application/json' },
         method: 'GET',
       });
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -302,7 +302,7 @@ export class ServiceClient {
       authenticate: false,
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
+        'Accept': 'application/json',
       },
     });
     await this.unwrap(response);
@@ -315,7 +315,7 @@ export class ServiceClient {
       authenticate: false,
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
+        'Accept': 'application/json',
       },
     });
     await this.unwrap(response);
@@ -754,7 +754,7 @@ export class ServiceClient {
   public async getProjectsList(): Promise<ProjectsListResponse> {
     const response: Response = await this.fetch('/projects', {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -770,7 +770,7 @@ export class ServiceClient {
 
     const response: Response = await this.fetch(projectUrl, {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -819,7 +819,7 @@ export class ServiceClient {
 
     const response: Response = await this.fetch(configUrl, {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -851,7 +851,7 @@ export class ServiceClient {
 
     const response: Response = await this.fetch(statisticsUrl, {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -881,7 +881,7 @@ export class ServiceClient {
 
     const response: Response = await this.fetch(providerChangesUrl, {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -951,7 +951,7 @@ export class ServiceClient {
   public async getUserInfo(): Promise<UserResponse> {
     const response: Response = await this.fetch(`/id/user`, {
       method: 'GET',
-      headers: { 'Content-Type': MEDIA_TYPE_JSON },
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
 
     await this.unwrap(response);
@@ -975,6 +975,7 @@ export class ServiceClient {
   private async fetchVerifyLogin(verifyUrl: string): Promise<VerifyResponse> {
     const result = await fetch(verifyUrl, {
       method: 'GET',
+      headers: { 'Accept': MEDIA_TYPE_JSON },
     });
     if (result.status === 200) {
       const authToken = (await result.json()) as AuthToken;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

<!--- Describe your changes in detail -->

This PR fixes missing `Accept` header in services API requests.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

New version of SF services will require valid Accept header to be set in API requests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
